### PR TITLE
Add code snippets for all location in SARIF output

### DIFF
--- a/lib/finalize-db.js
+++ b/lib/finalize-db.js
@@ -45,6 +45,7 @@ function run() {
                 const sarifFile = path.join(sarifFolder, database + '.sarif');
                 yield exec.exec(codeqlCmd, ['database', 'analyze', path.join(databaseFolder, database),
                     '--format=sarif-latest', '--output=' + sarifFile,
+                    '--sarif-add-snippets',
                     database + '-lgtm.qls']);
                 sarif_data = fs.readFileSync(sarifFile, 'utf8');
             }

--- a/src/finalize-db.ts
+++ b/src/finalize-db.ts
@@ -33,6 +33,7 @@ async function run() {
         const sarifFile = path.join(sarifFolder, database + '.sarif');
         await exec.exec(codeqlCmd, ['database', 'analyze', path.join(databaseFolder, database), 
                                     '--format=sarif-latest', '--output=' + sarifFile,
+                                    '--sarif-add-snippets',
                                     database + '-lgtm.qls']);
         sarif_data = fs.readFileSync(sarifFile,'utf8');
     }


### PR DESCRIPTION
Adding the `--sarif-add-snippets` flag should include code snippets to the sarif output.