### PR TITLE
Use check run name to determine which run to update

### DIFF
--- a/codeql/finish/action.yml
+++ b/codeql/finish/action.yml
@@ -4,7 +4,6 @@ author: 'GitHub'
 inputs:
   check_name:
     description: The name of the check run to add text to.
-    required: true
 runs:
   using: 'node12'
   main: '../../lib/finalize-db.js'

--- a/codeql/finish/action.yml
+++ b/codeql/finish/action.yml
@@ -1,7 +1,10 @@
 name: 'CodeQL: Finish'
 description: 'Finalize CodeQL database'
 author: 'GitHub'
-inputs: {}
+inputs:
+  check_name:
+    description: The name of the check run to add text to.
+    required: true
 runs:
   using: 'node12'
   main: '../../lib/finalize-db.js'

--- a/lib/extraction-and-analysis.js
+++ b/lib/extraction-and-analysis.js
@@ -1,9 +1,10 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };

--- a/lib/finalize-db.js
+++ b/lib/finalize-db.js
@@ -55,11 +55,17 @@ function run() {
             if (GITHUB_TOKEN && GITHUB_REF) {
                 const octokit = new github.GitHub(GITHUB_TOKEN);
                 const { data: checks } = yield octokit.checks.listForRef(Object.assign(Object.assign({}, github.context.repo), { ref: GITHUB_REF }));
-                console.log(checks.check_runs.map(run => run.name));
                 const check_name = core.getInput('check_name');
-                const check_run_id = checks.check_runs.filter(run => run.name === check_name)[0].id;
-                // We're only interested in the check runs created from this action.
-                // This filters out only those check runs that share our check run name
+                let check_run_id;
+                if (check_name) {
+                    check_run_id = checks.check_runs.filter(run => run.name === check_name)[0].id;
+                    // We're only interested in the check runs created from this action.
+                    // This filters out only those check runs that share our check run name
+                }
+                else {
+                    check_run_id = checks.check_runs[0].id;
+                    // if check_name is not provided, fallback to naively using the latest check run
+                }
                 console.log(Object.assign(Object.assign({}, github.context.repo), { check_run_id, output: {
                         title: 'SARIF alerts in a base64 zip',
                         summary: 'base64 zip',

--- a/lib/finalize-db.js
+++ b/lib/finalize-db.js
@@ -1,9 +1,10 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -53,15 +54,18 @@ function run() {
             const { GITHUB_TOKEN, GITHUB_REF } = process.env;
             if (GITHUB_TOKEN && GITHUB_REF) {
                 const octokit = new github.GitHub(GITHUB_TOKEN);
-                const { data: checks } = yield octokit.checks.listForRef(Object.assign({}, github.context.repo, { ref: GITHUB_REF }));
-                const check_run_id = checks.check_runs[0].id;
-                // this works as long as there's only one workflow
-                console.log(Object.assign({}, github.context.repo, { check_run_id, output: {
+                const { data: checks } = yield octokit.checks.listForRef(Object.assign(Object.assign({}, github.context.repo), { ref: GITHUB_REF }));
+                console.log(checks.check_runs.map(run => run.name));
+                const check_name = core.getInput('check_name');
+                const check_run_id = checks.check_runs.filter(run => run.name === check_name)[0].id;
+                // We're only interested in the check runs created from this action.
+                // This filters out only those check runs that share our check run name
+                console.log(Object.assign(Object.assign({}, github.context.repo), { check_run_id, output: {
                         title: 'SARIF alerts in a base64 zip',
                         summary: 'base64 zip',
                         text: zipped_sarif.length
                     } }));
-                yield octokit.checks.update(Object.assign({}, github.context.repo, { check_run_id, output: {
+                yield octokit.checks.update(Object.assign(Object.assign({}, github.context.repo), { check_run_id, output: {
                         title: 'SARIF alerts in a base64 zip',
                         summary: 'base64 zip',
                         text: zipped_sarif

--- a/lib/setup-codeql.js
+++ b/lib/setup-codeql.js
@@ -1,9 +1,10 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };

--- a/lib/setup-tools.js
+++ b/lib/setup-tools.js
@@ -1,9 +1,10 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };

--- a/lib/setup-tracer.js
+++ b/lib/setup-tracer.js
@@ -1,9 +1,10 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };

--- a/src/finalize-db.ts
+++ b/src/finalize-db.ts
@@ -27,11 +27,11 @@ async function run() {
 
     const sarifFolder = path.join(resultsFolder, 'sarif');
     io.mkdirP(sarifFolder);
-    
+
     let sarif_data = ' ';
     for (let database of fs.readdirSync(databaseFolder)) {
         const sarifFile = path.join(sarifFolder, database + '.sarif');
-        await exec.exec(codeqlCmd, ['database', 'analyze', path.join(databaseFolder, database), 
+        await exec.exec(codeqlCmd, ['database', 'analyze', path.join(databaseFolder, database),
                                     '--format=sarif-latest', '--output=' + sarifFile,
                                     '--sarif-add-snippets',
                                     database + '-lgtm.qls']);
@@ -49,12 +49,17 @@ async function run() {
             ref: GITHUB_REF
           });
 
-        console.log(checks.check_runs.map(run => run.name))
-
         const check_name = core.getInput('check_name');
-        const check_run_id = checks.check_runs.filter(run => run.name === check_name)[0].id
-        // We're only interested in the check runs created from this action.
-        // This filters out only those check runs that share our check run name
+
+        let check_run_id;
+        if (check_name) {
+          check_run_id = checks.check_runs.filter(run => run.name === check_name)[0].id
+          // We're only interested in the check runs created from this action.
+          // This filters out only those check runs that share our check run name
+        } else {
+          check_run_id = checks.check_runs[0].id
+          // if check_name is not provided, fallback to naively using the latest check run
+        }
 
         console.log({
          ...github.context.repo,

--- a/src/finalize-db.ts
+++ b/src/finalize-db.ts
@@ -49,8 +49,12 @@ async function run() {
             ref: GITHUB_REF
           });
 
-        const check_run_id = checks.check_runs[0].id;
-        // this works as long as there's only one workflow
+        console.log(checks.check_runs.map(run => run.name))
+
+        const check_name = core.getInput('check_name');
+        const check_run_id = checks.check_runs.filter(run => run.name === check_name)[0].id
+        // We're only interested in the check runs created from this action.
+        // This filters out only those check runs that share our check run name
 
         console.log({
          ...github.context.repo,


### PR DESCRIPTION
This brings back our approach of using the check run name to determine which check run to update. I've made this very flexible and if the `check_name` is not available from the action inputs, then we fallback to naively grabbing the latest check run. 