### PR TITLE
Fix typo - bellow -> below

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
       #   languages: go, javascript, csharp, python, cpp, java
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see bellow)
+    # If this step fails, then you should remove it and run the build manually (see below)
     # custom build steps.
     - name: Autobuild
       uses: Anthophila/codeql-action/codeql/autobuild@master


### PR DESCRIPTION
I spotted this in @jhutchings1's demo at All Hands.